### PR TITLE
CI: Disable builds on pull_request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,6 @@ name: smalltalkCI
 
 on:
   push:
-  pull_request:
   schedule:
     - cron: "0 0 * * 1"
 


### PR DESCRIPTION
Just like https://github.com/LinqLover/TelegramSmalltalkBot/commit/3e88f441c989f3d8fba72c978d438788ff365f92, we now are using the "Require branches to be up to date before merging" setting instead use.