### PR TITLE
Revise shutDown behavior

### DIFF
--- a/src/TelegramBot-Core.package/Behavior.extension/instance/shutDown.during..st
+++ b/src/TelegramBot-Core.package/Behavior.extension/instance/shutDown.during..st
@@ -1,0 +1,6 @@
+*TelegramBot-Core-system startup-pseudo-override
+shutDown: quitting during: aBlock
+
+	self shutDown: quitting.
+	^ aBlock ensure: [
+		self startUp: quitting]

--- a/src/TelegramBot-Core.package/Behavior.extension/methodProperties.json
+++ b/src/TelegramBot-Core.package/Behavior.extension/methodProperties.json
@@ -1,0 +1,5 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"shutDown:during:" : "ct 3/22/2021 14:56" } }

--- a/src/TelegramBot-Core.package/Behavior.extension/properties.json
+++ b/src/TelegramBot-Core.package/Behavior.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "Behavior" }

--- a/src/TelegramBot-Core.package/TelegramBot.class/instance/shutDown.during..st
+++ b/src/TelegramBot-Core.package/TelegramBot.class/instance/shutDown.during..st
@@ -3,8 +3,6 @@ shutDown: quitting during: aBlock
 	"Shut down the receiver while the system and shut down and started up during aBlock. If a process is running, give it a chance to process already retrieved updates and then suspend it."
 
 	| semaphore blocker |
-	quitting ifFalse: [
-		^ aBlock value].
 	(process isNil
 		or: [process isSuspended]
 		or: [process isTerminated]

--- a/src/TelegramBot-Core.package/TelegramBot.class/methodProperties.json
+++ b/src/TelegramBot-Core.package/TelegramBot.class/methodProperties.json
@@ -70,7 +70,7 @@
 		"serverUrl" : "ct 10/2/2020 17:35",
 		"shortPollingTimeout" : "ct 9/29/2020 14:32",
 		"shutDown:" : "ct 10/2/2020 17:35",
-		"shutDown:during:" : "ct 2/3/2021 00:33",
+		"shutDown:during:" : "ct 3/22/2021 14:12",
 		"spawnNewProcess" : "ct 2/3/2021 01:14",
 		"spawnNewProcessAt:" : "ct 2/3/2021 01:14",
 		"startUp:" : "ct 10/2/2020 17:35",

--- a/src/TelegramBot-Tests.package/TelegramBotRequestTest.class/instance/testProcess.st
+++ b/src/TelegramBot-Tests.package/TelegramBotRequestTest.class/instance/testProcess.st
@@ -15,11 +15,11 @@ testProcess
 		Processor yield.
 		self assert: 1 equals: mockBot receivedMessages size.
 		
-		mockBot shutDown: true.
+		mockBot shutDown: false.
 		[mockBot addUpdate: (self mockMessageFor: text id: 2 chatId: chatId).
 		Processor yield.
 		self assert: 1 equals: mockBot receivedMessages size]
-			ensure: [mockBot startUp: true].
+			ensure: [mockBot startUp: false].
 		Processor yield; yield; yield. "compensate the magic in Process>>pvtSignal:list:"
 		self assert: 2 equals: mockBot receivedMessages size.
 		

--- a/src/TelegramBot-Tests.package/TelegramBotRequestTest.class/methodProperties.json
+++ b/src/TelegramBot-Tests.package/TelegramBotRequestTest.class/methodProperties.json
@@ -11,7 +11,7 @@
 		"testDisableNotification" : "ct 3/7/2021 21:05",
 		"testDisableWebPagePreview" : "ct 3/7/2021 21:07",
 		"testParseCommand" : "ct 10/3/2020 18:33",
-		"testProcess" : "ct 2/3/2021 02:13",
+		"testProcess" : "ct 3/22/2021 15:04",
 		"testReceiveMessage" : "ct 2/3/2021 01:21",
 		"testSendAnimation" : "ct 3/7/2021 21:05",
 		"testSendAudio" : "ct 3/7/2021 21:05",


### PR DESCRIPTION
- Always interrupt bot processes during shutDown, even if non-quitting (82f6053)

  This will be relevant for installing updates in server images where the image does not need to be restarted in order to install updates.

- Add convenience selector for shutting down behaviors temporarily (d933290)

- Update tests