### PR TITLE
Baseline: Robustize #depInbox: against merged inbox prevdeps

### DIFF
--- a/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depInbox..st
+++ b/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depInbox..st
@@ -1,4 +1,7 @@
 scripts
 depInbox: aString
 
-	^ self depSqueakSource: #inbox name: aString
+	^ self
+		depSqueakSource: #inbox
+		name: aString
+		targetRepository: #trunk

--- a/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depSqueakSource.name..st
+++ b/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depSqueakSource.name..st
@@ -1,9 +1,7 @@
 scripts
 depSqueakSource: aMCRepository name: aString
 
-	(aMCRepository isKindOf: MCRepository) ifFalse: [
-		^ self depSqueakSource: (MCRepository in: aMCRepository) name: aString].
-	
-	^ ('{1} ({2})' format: {aString. aMCRepository description}) -> [Installer new
-		primMerge: aString , '.mcz'
-		from: aMCRepository]
+	^ self
+		depSqueakSource: aMCRepository
+		name: aString
+		targetRepository: nil

--- a/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depSqueakSource.name.targetRepository..st
+++ b/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/instance/depSqueakSource.name.targetRepository..st
@@ -1,0 +1,23 @@
+scripts
+depSqueakSource: aMCRepository name: aString targetRepository: anotherMCRepository
+
+	(aMCRepository isKindOf: MCRepository) ifFalse: [
+		^ self depSqueakSource: (MCRepository in: aMCRepository) name: aString targetRepository: anotherMCRepository].
+	(anotherMCRepository isKindOf: MCRepository) ifFalse: [
+		^ self depSqueakSource: aMCRepository name: aString targetRepository: (MCRepository in: anotherMCRepository)].
+	
+	^ ('{1} ({2})' format: {aString. aMCRepository description}) -> [
+		| packageName |
+		packageName := aString , '.mcz'.
+		[Installer new
+			primMerge: packageName
+			from: aMCRepository]
+				on: MCPackageNotFound
+				do: [:ex |
+					(anotherMCRepository notNil and: [ex repository == aMCRepository] and: [ex packageName = packageName])
+						ifFalse: [ex pass].
+					self notify: ('Preview version {1} has already been integrated' format: {aString})]
+				on: MCMergeResolutionRequest
+				do: [:ex |
+					Smalltalk isHeadless ifFalse: [ex pass].
+					self error: ex description] ]

--- a/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/methodProperties.json
+++ b/src/BaselineOfTelegramBot.package/BaselineOfTelegramBot.class/methodProperties.json
@@ -4,7 +4,8 @@
 	"instance" : {
 		"baseline:" : "ct 3/20/2021 14:57",
 		"depChangeset:" : "ct 3/4/2021 15:18",
-		"depInbox:" : "ct 11/22/2020 16:03",
-		"depSqueakSource:name:" : "ct 11/22/2020 16:06",
+		"depInbox:" : "ct 4/12/2021 22:28",
+		"depSqueakSource:name:" : "ct 4/12/2021 22:27",
+		"depSqueakSource:name:targetRepository:" : "ct 4/12/2021 22:45",
 		"installPreviewDependencies" : "ct 3/6/2021 17:03",
 		"projectClass" : "ct 10/6/2020 22:50" } }


### PR DESCRIPTION
Robustize BaselineOfTelegramBot >> #depInbox: against merged inbox prevdeps.

Cherry-picked from https://github.com/LinqLover/SimulationStudio/pull/24/commits/463cc273263e71052290ae46a5ddcd19f0720d8a